### PR TITLE
Show station name in pop-up

### DIFF
--- a/src/the-map.tsx
+++ b/src/the-map.tsx
@@ -85,8 +85,6 @@ export function TheMap({ selectedRoutes }: Props) {
                 // depending on the user-agent's language setting (if the
                 // translation string is available in the JSON)
                 layer.bindPopup(feature.properties.tags.name)
-                console.log(feature)
-                console.log(layer)
               }}
             />
           </ErrorBoundary>

--- a/src/the-map.tsx
+++ b/src/the-map.tsx
@@ -68,7 +68,26 @@ export function TheMap({ selectedRoutes }: Props) {
       {Object.entries(routesStations).map(([id, rs]) =>
         selectedRoutes.has(id) ? (
           <ErrorBoundary>
-            <GeoJSON key={`route-stations-${id}`} data={rs!} />
+            <GeoJSON
+              key={`route-stations-${id}`}
+              data={rs!}
+              style={() => ({
+                title: 'uniqueTitleqwe',
+                iconSize: [25, 41],
+                iconAnchor: [12, 41],
+                color: '#00FF00',
+                weight: 0.9,
+                fillColor: '#1a1d62',
+                fillOpacity: 1,
+              })}
+              onEachFeature={(feature, layer) =>
+                // TODO consider using `name:ru` to load the Russian label,
+                // depending on the user-agent's language setting
+                layer.bindPopup(feature.properties.tags.name)
+                // console.log(feature)
+                // console.log(layer)
+              }
+            />
           </ErrorBoundary>
         ) : (
           undefined

--- a/src/the-map.tsx
+++ b/src/the-map.tsx
@@ -80,13 +80,14 @@ export function TheMap({ selectedRoutes }: Props) {
                 fillColor: '#1a1d62',
                 fillOpacity: 1,
               })}
-              onEachFeature={(feature, layer) =>
+              onEachFeature={(feature, layer) => {
                 // TODO consider using `name:ru` to load the Russian label,
-                // depending on the user-agent's language setting
+                // depending on the user-agent's language setting (if the
+                // translation string is available in the JSON)
                 layer.bindPopup(feature.properties.tags.name)
-                // console.log(feature)
-                // console.log(layer)
-              }
+                console.log(feature)
+                console.log(layer)
+              }}
             />
           </ErrorBoundary>
         ) : (


### PR DESCRIPTION
This solves https://github.com/roataway/web-ui/issues/28 The popup is shown, so I'm quite happy. However, I have some questions, @iamandrewluca:

1. The JSONS we extract from OpenStreetMap also have a Russian translation of each station name, it is in a key called `"name:ru"` - it seems to be a good idea to extract that particular string, if we know that the users' language is Russian. I think we can take that from the `Accept-language` header, or let them set a language in the site's menu (and then save it somehow). What is the best way to extract the language and how should it be stored in the program's state?


2. I also attempted to resolve https://github.com/roataway/web-ui/issues/27 by providing a custom style, to override `iconSize` and `iconAnchor` (as discussed in the references linked by that issue). However, it seems that the styles are ignored. Just to be sure, I added a custom title - and that doesn't show up either. Is there some obvious detail that I have omitted? (I am following this documentation: https://www.wrld3d.com/wrld.js/latest/docs/leaflet/L.GeoJSON/)