### PR TITLE
Map tweaks

### DIFF
--- a/src/components/routes-positions.module.scss
+++ b/src/components/routes-positions.module.scss
@@ -1,3 +1,3 @@
 .markerImg {
-  transition: all 4s;
+  transition: all 10s;
 }

--- a/src/the-map.tsx
+++ b/src/the-map.tsx
@@ -50,10 +50,9 @@ export function TheMap(props: Props) {
       zoomControl={false}
       viewport={viewport}>
       <TileLayer
-        attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution="<a href='https://wikimediafoundation.org/wiki/Maps_Terms_of_Use'>Wikimedia</a>"
+        url="https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}{r}.png"
       />
-
       {showUserLocation && <UserLocation />}
 
       <ZoomControl position={leftHanded ? 'bottomleft' : 'bottomright'} />


### PR DESCRIPTION
- Change tile provider to Wikimedia it provides better contrast, the vehicles are clearer, and the map is less cluttered.
- Change transition time to 10s (after introducing map matching, telemetry comes less often, but the frequency has been improved from once every 20s, to once every 10s).