### PR TITLE
Revert "Use Maptiler tiles and API key"

### DIFF
--- a/src/the-map.tsx
+++ b/src/the-map.tsx
@@ -50,8 +50,8 @@ export function TheMap(props: Props) {
       zoomControl={false}
       viewport={viewport}>
       <TileLayer
-        attribution='<a href="https://www.maptiler.com/copyright/" target="_blank">© MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">© OpenStreetMap contributors</a>'
-        url="https://api.maptiler.com/maps/streets/{z}/{x}/{y}.png?key=kkvVQYrpRAgd0J55hJz5"
+        attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
 
       {showUserLocation && <UserLocation />}


### PR DESCRIPTION
There are some side-effects that haven't been resolved yet.